### PR TITLE
Enable CI for commits and PRs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Install packages
-      run: sudo apt-get install freeglut3-dev libglfw3-dev libglew-dev
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends freeglut3-dev libglfw3-dev libglew-dev
 
     - uses: actions/checkout@v2
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,53 @@
+name: CMake
+
+on:
+  push:
+    branches-ignore: master
+  pull_request:
+    branches: master
+  workflow_dispatch:
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install packages
+      run: sudo apt-get install freeglut3 freeglut3-dev libglew1.5 libglew1.5-dev libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{github.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+
+#     - name: Test
+#       working-directory: ${{github.workspace}}/build
+#       shell: bash
+#       # Execute tests defined by the CMake configuration.  
+#       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+#       run: ctest -C $BUILD_TYPE

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches-ignore: master
+    branches-ignore: [ main ]
   pull_request:
-    branches: master
+    branches: [ main ]
   workflow_dispatch:
 
 env:
@@ -21,7 +21,9 @@ jobs:
 
     steps:
     - name: Install packages
-      run: sudo apt-get install freeglut3 freeglut3-dev libglew1.5 libglew1.5-dev libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev
+      run: sudo apt-get install freeglut3 freeglut3-dev libglew1.5 libglew1.5-dev \
+                                libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev \
+                                libglfw3 libglfw3-dev
     - uses: actions/checkout@v2
 
     - name: Create Build Environment

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,13 +17,13 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    # switch to ubuntu-latest when GitHub updates https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Install packages
-      run: sudo apt-get install freeglut3 freeglut3-dev libglew1.5 libglew1.5-dev \
-                                libglu1-mesa libglu1-mesa-dev libgl1-mesa-glx libgl1-mesa-dev \
-                                libglfw3 libglfw3-dev
+      run: sudo apt-get install freeglut3-dev libglfw3-dev libglew-dev
+
     - uses: actions/checkout@v2
 
     - name: Create Build Environment
@@ -46,10 +46,3 @@ jobs:
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
-
-#     - name: Test
-#       working-directory: ${{github.workspace}}/build
-#       shell: bash
-#       # Execute tests defined by the CMake configuration.  
-#       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-#       run: ctest -C $BUILD_TYPE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
 project(trian
 	DESCRIPTION "inglor's Delaunay triangulation"
 	HOMEPAGE_URL "https://github.com/inglor/trian"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:20.04
+
+WORKDIR /usr/src/app
+
+COPY . ./
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/London
+
+RUN apt-get update -y && \
+    apt-get install -y tzdata
+
+RUN apt-get install -y --no-install-recommends \
+      gcc-9 \
+      g++ \
+      clang-10 \
+      build-essential \
+      cmake \
+      ca-certificates \
+      freeglut3-dev \
+      libglfw3-dev \
+      libglew-dev && \
+    apt-get autoclean && \
+    apt-get autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN rm -rf build; mkdir build; cd build; cmake ../; make


### PR DESCRIPTION
- Reduce `cmake` version to `3.16`
- Enables GitHub Actions for 
  - Building on push commits on all branches except `main`
  - Building on opening a PR against `main`
- Add a `Dockerfile` for local testing on a consistent manner
